### PR TITLE
Fix calendar import in server

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -316,7 +316,9 @@ app.get('/api/ical/:userId', async (req: Request, res: Response): Promise<void> 
     const userTimeBlocks = timeBlocks.filter(
       block => block.user_id === userId || block.user_id === 'temp-user'
     );
-    const { CalendarGenerator } = await import('./src/lib/calendar.js');
+    // Use extensionless import so ts-node can resolve the TypeScript file in
+    // development and Node can load the compiled JavaScript in production.
+    const { CalendarGenerator } = await import('./src/lib/calendar');
     const icsContent = CalendarGenerator.timeBlocksToICS(userTimeBlocks);
 
     res.setHeader('Content-Type', 'text/calendar; charset=utf-8');


### PR DESCRIPTION
## Summary
- use extensionless calendar import so ts-node resolves the TypeScript module

## Testing
- `npm --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e7067d7c83268a2f51609f34c97c