### PR TITLE
Add vitest script

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -9,7 +9,7 @@
 | `pnpm run build` | Build the project for production (client) |
 | `pnpm run preview` | Preview the production build locally (client) |
 | `pnpm run lint` | Run ESLint for code quality checks (client) |
-| `pnpm test` | Run the test suite with Vitest (client) |
+| `pnpm test` | Run the unit test suite with Vitest (root) |
 | `pnpm run test:e2e` | Run end-to-end tests with Playwright (client) |
 | `npm run server` | Start the Express backend server |
 
@@ -30,8 +30,8 @@
    ```bash
    # Run linting (from /client directory)
    pnpm run lint
-   
-   # Run tests (from /client directory)
+
+   # Run tests (from repository root)
    pnpm test
    ```
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -5,7 +5,7 @@
 
 ### Running Tests
 ```bash
-# From /client directory
+# From the repository root
 
 # Run all tests
 pnpm test

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
- add a `test` script to run Vitest
- update docs to clarify running tests from repo root

## Testing
- `pnpm test -- --config vite.config.test.ts` *(fails: Playwright tests picked up by Vitest)*

------
https://chatgpt.com/codex/tasks/task_e_684ca00e080c8326b98e434d1d1d0da4