### PR TITLE
Fix absolute path import

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/contexts/AuthContext";
-import { ProtectedRoute } from "/Users/malachiledbetter/Documents/GitHub/life-flow-ai-coach/client/src/components/ProtectedRoute.tsx";
+import { ProtectedRoute } from "@/components/ProtectedRoute";
 import { Index } from "./pages/index";
 import Auth from "./pages/Auth";
 import NotFound from "./pages/NotFound";


### PR DESCRIPTION
## Summary
- import `ProtectedRoute` using alias instead of an absolute file path
- run lint and unit tests

## Testing
- `pnpm run lint` *(fails: Unexpected any, A `require()` style import is forbidden)*
- `pnpm run test` *(fails: 9 failed | 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684cc1e6522483268ca61462e70224d6