### PR TITLE
Add env vars for Supabase config

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+SUPABASE_URL=https://your-supabase-url.supabase.co
+SUPABASE_ANON_KEY=your_supabase_anon_key

--- a/README.md
+++ b/README.md
@@ -78,7 +78,13 @@ The client will be available at `http://localhost:5173`
    CORS_ORIGIN=http://localhost:5173
    ```
 
-5. Start the development server:
+5. Create a `.env` file in the repository root and add your Supabase credentials:
+   ```
+   SUPABASE_URL=your_supabase_url
+   SUPABASE_ANON_KEY=your_supabase_anon_key
+   ```
+
+6. Start the development server:
    ```bash
    npm run dev
    ```
@@ -98,8 +104,8 @@ The API server will be available at `http://localhost:3000`
 1. Connect your repository to Vercel
 2. Set the root directory to `client`
 3. Configure environment variables in Vercel dashboard:
-   - `VITE_SUPABASE_URL`
-   - `VITE_SUPABASE_ANON_KEY`
+   - `VITE_SUPABASE_URL` / `SUPABASE_URL`
+   - `VITE_SUPABASE_ANON_KEY` / `SUPABASE_ANON_KEY`
    - `VITE_API_BASE_URL` (your deployed backend URL)
 4. Deploy automatically on push to main branch
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -27,8 +27,8 @@ vercel --prod
 1. **Vercel Dashboard Setup**:
    - Create "Development" and "Production" environments in your Vercel project
    - Set environment variables for each environment:
-     - `VITE_SUPABASE_URL` - Your Supabase project URL
-     - `VITE_SUPABASE_ANON_KEY` - Your Supabase anonymous key
+     - `VITE_SUPABASE_URL` / `SUPABASE_URL` - Your Supabase project URL
+     - `VITE_SUPABASE_ANON_KEY` / `SUPABASE_ANON_KEY` - Your Supabase anonymous key
      - `VITE_API_BASE_URL` - Your backend API URL
 
 2. **Package Manager Configuration**:
@@ -74,8 +74,8 @@ pnpm run preview
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `VITE_SUPABASE_URL` | Your Supabase project URL | `https://xxx.supabase.co` |
-| `VITE_SUPABASE_ANON_KEY` | Supabase anonymous public key | `eyJ...` |
+| `VITE_SUPABASE_URL` / `SUPABASE_URL` | Your Supabase project URL | `https://xxx.supabase.co` |
+| `VITE_SUPABASE_ANON_KEY` / `SUPABASE_ANON_KEY` | Supabase anonymous public key | `eyJ...` |
 | `VITE_API_BASE_URL` | Backend API URL | `http://localhost:3000` |
 
 ### Optional

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -2,6 +2,11 @@
 import { useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 
+const SUPABASE_URL =
+  import.meta.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL
+const SUPABASE_ANON_KEY =
+  import.meta.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY
+
 interface Message {
   id: string;
   content: string;
@@ -35,11 +40,11 @@ export const useChat = () => {
 
     try {
       // Use the new API endpoint
-      const response = await fetch('https://ceeobnncvfsqqliojsxn.supabase.co/functions/v1/gpt-chat', {
+      const response = await fetch(`${SUPABASE_URL}/functions/v1/gpt-chat`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImNlZW9ibm5jdmZzcXFsaW9qc3huIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDgxOTkwODksImV4cCI6MjA2Mzc3NTA4OX0.UJShCgS3BdR0KUKN5OPS_WJbjJgUKJhIMm1pbmXv9Bw`
+          'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
         },
         body: JSON.stringify({ 
           message: content, 

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,14 @@
 import { createClient } from '@supabase/supabase-js'
 import type { Database } from './types'
 
-const supabaseUrl = 'https://ceeobnncvfsqqliojsxn.supabase.co'
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImNlZW9ibm5jdmZzcXFsaW9qc3huIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDgxOTkwODksImV4cCI6MjA2Mzc3NTA4OX0.UJShCgS3BdR0KUKN5OPS_WJbjJgUKJhIMm1pbmXv9Bw'
+const supabaseUrl =
+  import.meta.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL
+const supabaseAnonKey =
+  import.meta.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Missing Supabase environment variables')
+}
 
 export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
   auth: {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,8 @@
 
-const SUPABASE_URL = "https://ceeobnncvfsqqliojsxn.supabase.co"
+const SUPABASE_URL =
+  import.meta.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL
+const SUPABASE_ANON_KEY =
+  import.meta.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY
 
 export const sendChatMessage = async (message: string, messages: any[] = [], userId: string) => {
   try {
@@ -7,7 +10,7 @@ export const sendChatMessage = async (message: string, messages: any[] = [], use
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImNlZW9ibm5jdmZzcXFsaW9qc3huIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDgxOTkwODksImV4cCI6MjA2Mzc3NTA4OX0.UJShCgS3BdR0KUKN5OPS_WJbjJgUKJhIMm1pbmXv9Bw'}`
+        'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
       },
       body: JSON.stringify({ message, messages, userId })
     })


### PR DESCRIPTION
## Summary
- load Supabase credentials from `.env`
- document new `SUPABASE_URL` and `SUPABASE_ANON_KEY` vars
- update Supabase client, API helper and chat hook to use env vars

## Testing
- `pnpm test` *(fails: Playwright tests expect env vars)*

------
https://chatgpt.com/codex/tasks/task_e_684cc5c60db483268df72fd03e5276c9