### PR TITLE
Fix playwright test dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
-    "@playwright/test": "^1.52.0",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.1",
     "@radix-ui/react-aspect-ratio": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@hookform/resolvers':
         specifier: ^3.9.0
         version: 3.10.0(react-hook-form@7.56.4(react@18.3.1))
-      '@playwright/test':
-        specifier: ^1.52.0
-        version: 1.52.0
       '@radix-ui/react-accordion':
         specifier: ^1.2.0
         version: 1.2.11(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -186,6 +183,9 @@ importers:
       '@eslint/js':
         specifier: ^9.9.0
         version: 9.28.0
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.52.0
       '@tailwindcss/typography':
         specifier: ^0.5.15
         version: 0.5.16(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@22.15.29)(typescript@5.8.3)))


### PR DESCRIPTION
## Summary
- keep `@playwright/test` only in devDependencies
- refresh pnpm lockfile

## Testing
- `pnpm test` *(fails: Missing Supabase env vars)*

------
https://chatgpt.com/codex/tasks/task_e_684ced41e07c832694b2a7d610d98f9a