### PR TITLE
Remove legacy server directory docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Your intelligent companion for meal planning, task management, workout tracking,
 
 ## Project Structure
 
-This repository is split into client and server components:
+This repository consists of a React client and a small Node backend:
 
 - `/client/` - React + Vite frontend application
 - `/src/` - TypeScript backend utilities used by `server.ts`
-- `/server/` - Express backend server and API routes (legacy)
+- `server.ts` - Express backend entry point
 
 `src/` still contains some legacy client code that is no longer used. The active
 React application lives entirely under `client/src`.
@@ -61,44 +61,30 @@ The client will be available at `http://localhost:5173`
 
 ### Backend (Server)
 
-1. Navigate to the server directory:
+1. Install backend dependencies from the repository root:
    ```bash
-   cd server
+   pnpm install
    ```
 
-2. Install dependencies:
-   ```bash
-   npm install
+2. Create a `.env` file in the repository root and add your credentials:
    ```
-
-3. Copy environment variables:
-   ```bash
-   cp .env.example .env
-   ```
-
-4. Configure your environment variables in `.env`:
-   ```
+   SUPABASE_URL=your_supabase_url
+   SUPABASE_ANON_KEY=your_supabase_anon_key
    OPENAI_API_KEY=your_openai_api_key
    PORT=3000
    CORS_ORIGIN=http://localhost:5173
    ```
 
-5. Create a `.env` file in the repository root and add your Supabase credentials:
-   ```
-   SUPABASE_URL=your_supabase_url
-   SUPABASE_ANON_KEY=your_supabase_anon_key
-   ```
-
-6. Start the development server:
+3. Start the development server:
    ```bash
-   npm run dev
+   pnpm run server
    ```
 
 The API server will be available at `http://localhost:3000`
 
 ## Development Workflow
 
-1. Start the backend server from the `/server` directory
+1. Start the backend server from the repository root using `pnpm run server`
 2. Start the frontend development server from the `/client` directory using pnpm
 3. The frontend will make API requests to the backend
 
@@ -119,7 +105,7 @@ The API server will be available at `http://localhost:3000`
 
 #### Using Railway:
 1. Connect your repository to Railway
-2. Set the root directory to `server`
+2. Set the root directory to the repository root
 3. Configure environment variables:
    - `OPENAI_API_KEY`
    - `PORT` (Railway will set this automatically)
@@ -129,17 +115,11 @@ The API server will be available at `http://localhost:3000`
 #### Using Render:
 1. Connect your repository to Render
 2. Choose "Web Service"
-3. Set the root directory to `server`
-4. Build command: `npm install && npm run build`
-5. Start command: `npm run start`
+3. Set the root directory to the repository root
+4. Build command: `pnpm install && pnpm run build:backend`
+5. Start command: `pnpm run start:prod`
 6. Configure environment variables in Render dashboard
 
-#### Using Docker:
-```bash
-cd server
-docker build -t life-flow-server .
-docker run -p 3000:3000 -e OPENAI_API_KEY=your_key life-flow-server
-```
 
 ## Database Setup
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -67,9 +67,9 @@ pnpm run preview
 
 1. Create a new service on Railway or Heroku
 2. Connect your GitHub repository
-3. Set the root directory to `server`
+3. Set the root directory to the repository root
 4. Set the `OPENAI_API_KEY` environment variable
-5. Deploy the server using the provided workflows
+5. Deploy the server using the provided workflows (`pnpm run start:prod`)
 
 ## Environment Variables
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -11,7 +11,7 @@
 | `pnpm run lint` | Run ESLint for code quality checks (client) |
 | `pnpm test` | Run the unit test suite with Vitest (root) |
 | `pnpm run test:e2e` | Run end-to-end tests with Playwright (client) |
-| `npm run server` | Start the Express backend server |
+| `pnpm run server` | Start the backend server |
 
 ## Development Workflow
 
@@ -21,9 +21,8 @@
    cd client
    pnpm run dev
    
-   # Terminal 2: Start the server (from /server directory)
-   cd server
-   npm run dev
+    # Terminal 2: Start the server (from repository root)
+    pnpm run server
    ```
 
 2. **Code Quality**
@@ -47,7 +46,7 @@
 ## Package Management
 
 - **Frontend (Client)**: Uses pnpm for faster installs and better dependency management
-- **Backend (Server)**: Uses npm (can be migrated to pnpm later if needed)
+ - **Backend (Server)**: Uses pnpm as well
 
 ### Installing Dependencies
 
@@ -57,10 +56,9 @@ cd client
 pnpm add package-name
 pnpm add -D dev-package-name
 
-# Server dependencies  
-cd server
-npm install package-name
-npm install --save-dev dev-package-name
+# Backend dependencies
+pnpm add package-name
+pnpm add -D dev-package-name
 ```
 
 ## Development Tips
@@ -80,8 +78,8 @@ npm install --save-dev dev-package-name
 
 ## Build Pipeline
 
-The project uses pnpm for the client and npm for the server:
+The project uses pnpm for both the client and the backend:
 - Client builds with Vite and pnpm
-- Server builds with Node.js and npm
-- CI/CD uses pnpm for client dependencies
+- Server runs via `server.ts` with pnpm
+- CI/CD uses pnpm for all dependencies
 - Vercel deployment automatically detects pnpm via .npmrc


### PR DESCRIPTION
## Summary
- clean up README and docs to stop referencing the old `/server` folder
- update instructions for starting and deploying the backend via `server.ts`
- align development guide with pnpm usage

## Testing
- `pnpm test` *(fails: Missing Supabase env vars and Playwright suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ced4456e48326b81d34cd9e9e7772