### PR TITLE
Add .env example files for client and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,23 +73,19 @@ The client will be available at `http://localhost:5173`
 
 3. Copy environment variables:
    ```bash
-   cp .env.example .env
+   cp ../server.env.example .env
    ```
 
 4. Configure your environment variables in `.env`:
    ```
    OPENAI_API_KEY=your_openai_api_key
+   SUPABASE_URL=your_supabase_url
+   SUPABASE_ANON_KEY=your_supabase_anon_key
    PORT=3000
    CORS_ORIGIN=http://localhost:5173
    ```
 
-5. Create a `.env` file in the repository root and add your Supabase credentials:
-   ```
-   SUPABASE_URL=your_supabase_url
-   SUPABASE_ANON_KEY=your_supabase_anon_key
-   ```
-
-6. Start the development server:
+5. Start the development server:
    ```bash
    npm run dev
    ```

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for the client
+VITE_SUPABASE_URL=https://your_supabase_url.supabase.co
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+VITE_API_BASE_URL=http://localhost:3000
+API_BASE_URL=http://localhost:5000

--- a/server.env.example
+++ b/server.env.example
@@ -1,0 +1,6 @@
+# Example environment variables for the backend server
+OPENAI_API_KEY=your_openai_api_key
+SUPABASE_URL=https://your_supabase_url.supabase.co
+SUPABASE_ANON_KEY=your_supabase_anon_key
+PORT=3000
+CORS_ORIGIN=http://localhost:5173


### PR DESCRIPTION
## Summary
- add example env file for client with Supabase & API variables
- add example server env file with OpenAI & Supabase keys
- update README server setup steps to copy and use these files

## Testing
- `pnpm test` *(fails: Playwright did not expect test.describe, missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_684ced4704408326a5e9c2eade87a397