### PR TITLE
Add server-side Supabase client

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,7 +1,7 @@
 
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { User, Session } from '@supabase/supabase-js';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/integrations/supabase';
 
 interface AuthContextType {
   user: User | null;

--- a/src/hooks/useMeals.ts
+++ b/src/hooks/useMeals.ts
@@ -4,7 +4,7 @@ import { mealsService } from '@/services/mealsService';
 import { Meal, CreateMeal, UpdateMeal } from '@/types/database';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/contexts/AuthContext';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/integrations/supabase';
 import { useEffect } from 'react';
 
 export const useMeals = () => {

--- a/src/hooks/useReminders.ts
+++ b/src/hooks/useReminders.ts
@@ -4,7 +4,7 @@ import { remindersService } from '@/services/remindersService';
 import { Reminder, CreateReminder, UpdateReminder } from '@/types/database';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/contexts/AuthContext';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/integrations/supabase';
 import { useEffect } from 'react';
 
 export const useReminders = () => {

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -4,7 +4,7 @@ import { tasksService } from '@/services/tasksService';
 import { Task, CreateTask, UpdateTask } from '@/types/database';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/contexts/AuthContext';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/integrations/supabase';
 import { useEffect } from 'react';
 
 export const useTasks = () => {

--- a/src/hooks/useTimeBlocks.ts
+++ b/src/hooks/useTimeBlocks.ts
@@ -4,7 +4,7 @@ import { timeBlocksService } from '@/services/timeBlocksService';
 import { TimeBlock, CreateTimeBlock, UpdateTimeBlock } from '@/types/database';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/contexts/AuthContext';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/integrations/supabase';
 import { useEffect } from 'react';
 
 export const useTimeBlocks = () => {

--- a/src/hooks/useWorkouts.ts
+++ b/src/hooks/useWorkouts.ts
@@ -4,7 +4,7 @@ import { workoutsService } from '@/services/workoutsService';
 import { Workout, CreateWorkout, UpdateWorkout } from '@/types/database';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/contexts/AuthContext';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/integrations/supabase';
 import { useEffect } from 'react';
 
 export const useWorkouts = () => {

--- a/src/integrations/supabase/index.ts
+++ b/src/integrations/supabase/index.ts
@@ -4,4 +4,8 @@ export { tasksApi } from './tasks';
 export { workoutsApi } from './workouts';
 export { remindersApi } from './reminders';
 export { timeBlocksApi } from './timeBlocks';
-export { supabase } from './client';
+
+import { supabase as browserSupabase } from './client';
+import { supabase as serverSupabase } from './serverClient';
+
+export const supabase = typeof window === 'undefined' ? serverSupabase : browserSupabase;

--- a/src/integrations/supabase/serverClient.ts
+++ b/src/integrations/supabase/serverClient.ts
@@ -1,0 +1,16 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from './types';
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Missing Supabase environment variables');
+}
+
+export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    persistSession: false,
+    autoRefreshToken: false,
+  },
+});

--- a/src/lib/planningAPI.ts
+++ b/src/lib/planningAPI.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/integrations/supabase';
 
 export interface PlanningRequest {
   goals: string[];

--- a/src/server/gptFunctions.ts
+++ b/src/server/gptFunctions.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '../integrations/supabase/client';
+import { supabase } from '../integrations/supabase';
 
 export const gptFunctions = [
   {

--- a/src/services/__tests__/authenticationTests.test.ts
+++ b/src/services/__tests__/authenticationTests.test.ts
@@ -1,6 +1,6 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/integrations/supabase';
 import { mealsService } from '@/services/mealsService';
 import { tasksService } from '@/services/tasksService';
 import { workoutsService } from '@/services/workoutsService';
@@ -8,7 +8,7 @@ import { remindersService } from '@/services/remindersService';
 import { timeBlocksService } from '@/services/timeBlocksService';
 
 // Mock the Supabase client
-vi.mock('@/integrations/supabase/client', () => ({
+vi.mock('@/integrations/supabase', () => ({
   supabase: {
     auth: {
       getUser: vi.fn()

--- a/src/services/mealsService.ts
+++ b/src/services/mealsService.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/integrations/supabase';
 import { Meal, CreateMeal, UpdateMeal } from '@/types/database';
 
 export const mealsService = {

--- a/src/services/remindersService.ts
+++ b/src/services/remindersService.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/integrations/supabase';
 import { Reminder, CreateReminder, UpdateReminder } from '@/types/database';
 
 export const remindersService = {

--- a/src/services/tasksService.ts
+++ b/src/services/tasksService.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/integrations/supabase';
 import { Task, CreateTask, UpdateTask } from '@/types/database';
 
 export const tasksService = {

--- a/src/services/timeBlocksService.ts
+++ b/src/services/timeBlocksService.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/integrations/supabase';
 import { TimeBlock, CreateTimeBlock, UpdateTimeBlock } from '@/types/database';
 
 export const timeBlocksService = {

--- a/src/services/workoutsService.ts
+++ b/src/services/workoutsService.ts
@@ -1,5 +1,5 @@
 
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/integrations/supabase';
 import { Workout, CreateWorkout, UpdateWorkout } from '@/types/database';
 
 export const workoutsService = {

--- a/src/utils/actionExecutor.ts
+++ b/src/utils/actionExecutor.ts
@@ -1,6 +1,6 @@
 
 import { useToast } from '@/hooks/use-toast';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '@/integrations/supabase';
 
 export interface GPTAction {
   type: 'addMeal' | 'addTask' | 'addWorkout' | 'addReminder' | 'addTimeBlock' | 'storeWorkoutPlan' | 'planDailyMeals';


### PR DESCRIPTION
## Summary
- create `serverClient.ts` to instantiate Supabase without browser storage
- select server or browser client automatically in `index.ts`
- update services and utilities to use the new index

## Testing
- `pnpm test` *(fails: Tests failed. Watching for file changes...)*
- `pnpm run test:e2e` *(fails: browser executables missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ced5020cc8326b96ff2a7f98406fd