### PR TITLE
Remove temp-user logic

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -485,24 +485,17 @@ app.post('/api/gpt', async (req: Request, res: Response): Promise<void> => {
 app.get('/api/ical/:userId', async (req: Request, res: Response): Promise<void> => {
   const { userId } = req.params;
 
-  // Validate that userId is provided and not empty
-  if (!userId || userId === 'undefined' || userId === 'null') {
-    return res.status(400).json({ 
+  // Validate that userId is provided and not a placeholder
+  if (!userId || userId === 'undefined' || userId === 'null' || userId === 'temp-user') {
+    return res.status(400).json({
       message: 'User ID is required for calendar export',
       error: 'Missing or invalid user ID'
     });
   }
+
   try {
     console.log('[ICAL REQUEST]', { userId });
     const timeBlocks = await timeBlocksService.getAll();
-    const userTimeBlocks = timeBlocks.filter(
-      block => block.user_id === userId || block.user_id === 'temp-user'
-    );
-    // Use extensionless import so ts-node can resolve the TypeScript file in
-    // development and Node can load the compiled JavaScript in production.
-    const { CalendarGenerator } = await import('./src/lib/calendar');
-    
-    // Filter time blocks for the specific authenticated user only
     const userTimeBlocks = timeBlocks.filter(block => block.user_id === userId);
 
     if (userTimeBlocks.length === 0) {

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -9,6 +9,7 @@ import { useWorkouts } from '@/hooks/useWorkouts';
 import { useReminders } from '@/hooks/useReminders';
 import { useTimeBlocks } from '@/hooks/useTimeBlocks';
 import { useMeals } from '@/hooks/useMeals';
+import { useAuth } from '@/contexts/AuthContext';
 import { 
   ChevronLeft, 
   ChevronRight, 
@@ -33,6 +34,7 @@ export const CalendarView = () => {
   const { reminders } = useReminders();
   const { timeBlocks } = useTimeBlocks();
   const { meals } = useMeals();
+  const { user } = useAuth();
 
   const getItemsForDate = (date: Date) => {
     const dateStr = format(date, 'yyyy-MM-dd');
@@ -61,9 +63,12 @@ export const CalendarView = () => {
   };
 
   const handleDownloadCalendar = async () => {
+    if (!user) {
+      toast({ title: 'Error', description: 'You must be logged in to export your calendar', variant: 'destructive' });
+      return;
+    }
     try {
-      // Use temp-user since we're not using real authentication yet
-      const response = await fetch('/api/ical/temp-user');
+      const response = await fetch(`/api/ical/${user.id}`);
       
       if (!response.ok) {
         throw new Error('Failed to generate calendar export');

--- a/src/server/__tests__/gptRouter.test.ts
+++ b/src/server/__tests__/gptRouter.test.ts
@@ -6,6 +6,7 @@ import { workoutsService } from '../../services/workoutsService';
 import { tasksService } from '../../services/tasksService';
 import { remindersService } from '../../services/remindersService';
 import { timeBlocksService } from '../../services/timeBlocksService';
+import { supabase } from '../../integrations/supabase/client';
 
 // Mock all services
 vi.mock('../../services/mealsService');
@@ -13,10 +14,21 @@ vi.mock('../../services/workoutsService');
 vi.mock('../../services/tasksService');
 vi.mock('../../services/remindersService');
 vi.mock('../../services/timeBlocksService');
+vi.mock('../../integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getUser: vi.fn()
+    }
+  }
+}));
 
 describe('parseFunctionCall', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(supabase.auth.getUser).mockResolvedValue({
+      data: { user: { id: 'test-user-id' } },
+      error: null
+    });
   });
 
   describe('createMeal', () => {
@@ -25,7 +37,7 @@ describe('parseFunctionCall', () => {
         id: 'test-id',
         name: 'Test Meal',
         meal_type: 'breakfast',
-        user_id: 'test-user',
+        user_id: 'test-user-id',
         created_at: new Date().toISOString(),
         planned_date: null,
         calories: null,
@@ -49,7 +61,7 @@ describe('parseFunctionCall', () => {
         calories: undefined,
         ingredients: undefined,
         instructions: undefined,
-        user_id: 'temp-user'
+        user_id: 'test-user-id'
       });
     });
 
@@ -72,7 +84,7 @@ describe('parseFunctionCall', () => {
         id: 'test-id',
         name: 'Test Workout',
         duration: 30,
-        user_id: 'test-user',
+        user_id: 'test-user-id',
         created_at: new Date().toISOString(),
         intensity: null,
         is_completed: false,
@@ -96,7 +108,7 @@ describe('parseFunctionCall', () => {
       const mockTask = {
         id: 'test-id',
         title: 'Test Task',
-        user_id: 'test-user',
+        user_id: 'test-user-id',
         created_at: new Date().toISOString(),
         description: null,
         due_date: null,
@@ -119,7 +131,7 @@ describe('parseFunctionCall', () => {
       const mockReminder = {
         id: 'test-id',
         title: 'Test Reminder',
-        user_id: 'test-user',
+        user_id: 'test-user-id',
         created_at: new Date().toISOString(),
         due_date: null,
         is_completed: false
@@ -141,7 +153,7 @@ describe('parseFunctionCall', () => {
       const mockTimeBlock = {
         id: 'test-id',
         title: 'Test Time Block',
-        user_id: 'test-user',
+        user_id: 'test-user-id',
         created_at: new Date().toISOString(),
         start_time: null,
         end_time: null,


### PR DESCRIPTION
## Summary
- use authenticated user id in CalendarView calendar export
- reject 'temp-user' in ical route
- mock authenticated user in gptRouter tests

## Testing
- `OPENAI_API_KEY="test" SUPABASE_URL="http://example.com" SUPABASE_ANON_KEY="anon" npx vitest run src/server/__tests__/gptRouter.test.ts` *(fails: Unknown function errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ced6076948326983881ef66ffe338