### PR TITLE
Update auth mocks in gptRouter tests

### DIFF
--- a/src/server/__tests__/gptRouter.test.ts
+++ b/src/server/__tests__/gptRouter.test.ts
@@ -1,25 +1,28 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { parseFunctionCall } from '../gptRouter';
-import { mealsService } from '../../services/mealsService';
-import { workoutsService } from '../../services/workoutsService';
-import { tasksService } from '../../services/tasksService';
-import { remindersService } from '../../services/remindersService';
-import { timeBlocksService } from '../../services/timeBlocksService';
 
-// Mock all services
-vi.mock('../../services/mealsService');
-vi.mock('../../services/workoutsService');
-vi.mock('../../services/tasksService');
-vi.mock('../../services/remindersService');
-vi.mock('../../services/timeBlocksService');
+vi.mock('../../integrations/supabase/client', () => {
+  return {
+    supabase: {
+      auth: { getUser: vi.fn() },
+      from: vi.fn()
+    }
+  };
+});
+
+import { supabase } from '../../integrations/supabase/client';
+import { parseFunctionCall } from '../gptRouter';
+
+const mockUser = { id: 'auth-user' };
+
+// Mock Supabase client
 
 describe('parseFunctionCall', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('createMeal', () => {
+  describe('addMeal', () => {
     it('should create a meal successfully', async () => {
       const mockMeal = {
         id: 'test-id',
@@ -33,40 +36,52 @@ describe('parseFunctionCall', () => {
         instructions: null
       };
 
-      vi.mocked(mealsService.create).mockResolvedValue(mockMeal);
+      const mockFrom = {
+        insert: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockMeal, error: null })
+      };
+      vi.mocked(supabase.from).mockReturnValue(mockFrom as any);
 
-      const result = await parseFunctionCall('createMeal', {
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({ data: { user: mockUser }, error: null });
+
+      const result = await parseFunctionCall('addMeal', {
         name: 'Test Meal',
         meal_type: 'breakfast'
       });
 
       expect(result.success).toBe(true);
-      expect(result.data).toEqual(mockMeal);
-      expect(mealsService.create).toHaveBeenCalledWith({
-        name: 'Test Meal',
-        meal_type: 'breakfast',
-        planned_date: undefined,
-        calories: undefined,
-        ingredients: undefined,
-        instructions: undefined,
-        user_id: 'temp-user'
-      });
+      expect(result.meal).toEqual(mockMeal);
+      expect(supabase.from).toHaveBeenCalledWith('meals');
+      expect(mockFrom.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Test Meal',
+          meal_type: 'breakfast',
+          user_id: mockUser.id
+        })
+      );
     });
 
     it('should handle errors when creating a meal', async () => {
       const error = new Error('Database error');
-      vi.mocked(mealsService.create).mockRejectedValue(error);
+      const mockFrom = {
+        insert: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        single: vi.fn().mockRejectedValue(error)
+      };
+      vi.mocked(supabase.from).mockReturnValue(mockFrom as any);
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({ data: { user: mockUser }, error: null });
 
-      const result = await parseFunctionCall('createMeal', {
+      const result = await parseFunctionCall('addMeal', {
         name: 'Test Meal'
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Database error');
+      expect(result.error).toBe('Unexpected error');
     });
   });
 
-  describe('scheduleWorkout', () => {
+  describe('addWorkout', () => {
     it('should schedule a workout successfully', async () => {
       const mockWorkout = {
         id: 'test-id',
@@ -79,15 +94,22 @@ describe('parseFunctionCall', () => {
         shceduled_date: null
       };
 
-      vi.mocked(workoutsService.create).mockResolvedValue(mockWorkout);
+      const mockFrom = {
+        insert: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockWorkout, error: null })
+      };
+      vi.mocked(supabase.from).mockReturnValue(mockFrom as any);
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({ data: { user: mockUser }, error: null });
 
-      const result = await parseFunctionCall('scheduleWorkout', {
+      const result = await parseFunctionCall('addWorkout', {
         name: 'Test Workout',
         duration: 30
       });
 
       expect(result.success).toBe(true);
-      expect(result.data).toEqual(mockWorkout);
+      expect(result.workout).toEqual(mockWorkout);
+      expect(supabase.from).toHaveBeenCalledWith('workouts');
     });
   });
 
@@ -103,14 +125,21 @@ describe('parseFunctionCall', () => {
         is_completed: false
       };
 
-      vi.mocked(tasksService.create).mockResolvedValue(mockTask);
+      const mockFrom = {
+        insert: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockTask, error: null })
+      };
+      vi.mocked(supabase.from).mockReturnValue(mockFrom as any);
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({ data: { user: mockUser }, error: null });
 
       const result = await parseFunctionCall('addTask', {
         title: 'Test Task'
       });
 
       expect(result.success).toBe(true);
-      expect(result.data).toEqual(mockTask);
+      expect(result.task).toEqual(mockTask);
+      expect(supabase.from).toHaveBeenCalledWith('tasks');
     });
   });
 
@@ -125,18 +154,25 @@ describe('parseFunctionCall', () => {
         is_completed: false
       };
 
-      vi.mocked(remindersService.create).mockResolvedValue(mockReminder);
+      const mockFrom = {
+        insert: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockReminder, error: null })
+      };
+      vi.mocked(supabase.from).mockReturnValue(mockFrom as any);
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({ data: { user: mockUser }, error: null });
 
       const result = await parseFunctionCall('addReminder', {
         title: 'Test Reminder'
       });
 
       expect(result.success).toBe(true);
-      expect(result.data).toEqual(mockReminder);
+      expect(result.reminder).toEqual(mockReminder);
+      expect(supabase.from).toHaveBeenCalledWith('reminders');
     });
   });
 
-  describe('createTimeBlock', () => {
+  describe('addTimeBlock', () => {
     it('should create a time block successfully', async () => {
       const mockTimeBlock = {
         id: 'test-id',
@@ -149,14 +185,21 @@ describe('parseFunctionCall', () => {
         linked_task_id: null
       };
 
-      vi.mocked(timeBlocksService.create).mockResolvedValue(mockTimeBlock);
+      const mockFrom = {
+        insert: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: mockTimeBlock, error: null })
+      };
+      vi.mocked(supabase.from).mockReturnValue(mockFrom as any);
+      vi.mocked(supabase.auth.getUser).mockResolvedValue({ data: { user: mockUser }, error: null });
 
-      const result = await parseFunctionCall('createTimeBlock', {
+      const result = await parseFunctionCall('addTimeBlock', {
         title: 'Test Time Block'
       });
 
       expect(result.success).toBe(true);
-      expect(result.data).toEqual(mockTimeBlock);
+      expect(result.timeBlock).toEqual(mockTimeBlock);
+      expect(supabase.from).toHaveBeenCalledWith('time_blocks');
     });
   });
 
@@ -165,7 +208,7 @@ describe('parseFunctionCall', () => {
       const result = await parseFunctionCall('unknownFunction', {});
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Unknown function: unknownFunction');
+      expect(result.error).toBe('Unknown function');
     });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,13 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    exclude: [
+      '**/node_modules/**',
+      'client/e2e/**',
+      'client/tests/**',
+      'tests/e2e/**'
+    ],
+    setupFiles: './vitest.setup.ts',
   },
   resolve: {
     alias: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+process.env.OPENAI_API_KEY = 'test-key';


### PR DESCRIPTION
## Summary
- mock Supabase auth in gptRouter tests and remove temp-user usage
- ignore e2e tests for unit test runs
- set OPENAI key for vitest

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684ced658ca48326a4e0aa414535c74f